### PR TITLE
fix: mounted the secrets directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       options: --user 1000:1000 --group-add 960 --group-add 987
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
+        - /opt/github-runner/secrets:/opt/github-runner/secrets:ro
     outputs:
       image-digest: ${{ steps.push-do.outputs.digest }}
       build-timestamp: ${{ steps.metadata.outputs.timestamp }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The [`attic_token`](./attic_token) file distributed with this repository has rea
 
 If you opt to prepare your own attic server, you will need to bootstrap Petros with some available attic binaries. Instructions for bootstrapping are provided [here](./BOOTSTRAP.md).
 
+## Local Testing
+
+This repository is configured to support testing the release workflow locally using the `act` tool. There is a corresponding goal in the Makefile, and instructions for further management of secrets [here](./docs/WORKFLOW_TESTING.md).
+
 ## Regarding Vendored Nix Packages
 
 The Nix packages are vendored to keep us pinned to a specific version and to support overriding some default mirrors. At the time of creating this project, the GNU FTP mirrors [were being attacked](https://www.fsf.org/blogs/sysadmin/our-small-team-vs-millions-of-bots). We had to update the sources used for some dependencies to ensure that alternative mirrors were used. We encourage donating to the Free Software Foundation [here](https://my.fsf.org/donate).


### PR DESCRIPTION
## Description
The self-hosted runner could not actually read the secrets that it needed for the release workflow.
