### PR TITLE
fix: pointing to accessible attic server

### DIFF
--- a/.env.maintainer
+++ b/.env.maintainer
@@ -9,7 +9,7 @@ IMAGE_NAME=petros
 DH_REPO=petros
 
 # The URL where the attic server can be reached.
-ATTIC_SERVER_URL=http://localhost:8080
+ATTIC_SERVER_URL=http://167.71.179.207:8080
 
 # The name of the attic cache to draw Nix binaries from.
 ATTIC_CACHE=sigil

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,18 +56,6 @@ jobs:
     - name: Load secrets and configuration
       id: load-config
       run: |
-        # Debug: Show where we are
-        echo "Current directory: $(pwd)"
-        echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
-        echo "Files in current directory:"
-        ls -la
-
-        # Explicitly change to repository root
-        cd $GITHUB_WORKSPACE
-        echo "After cd, current directory: $(pwd)"
-        echo "Files in GITHUB_WORKSPACE:"
-        ls -la
-
         # Load GitHub tokens from runner-local files
         CI_GH_PAT=$(cat /opt/github-runner/secrets/ci_gh_pat)
         CI_GH_CLASSIC_PAT=$(cat /opt/github-runner/secrets/ci_gh_classic_pat)
@@ -95,9 +83,6 @@ jobs:
         echo "GPG_PUBLIC_KEY=$GPG_PUBLIC_KEY" >> $GITHUB_ENV
 
         # Load public config from repository
-        echo "About to source .env.maintainer"
-        echo "File exists check: $(test -f .env.maintainer && echo 'YES' || echo 'NO')"
-        echo "File readable check: $(test -r .env.maintainer && echo 'YES' || echo 'NO')"
         . "$GITHUB_WORKSPACE/.env.maintainer"
 
         # Export to environment for subsequent steps


### PR DESCRIPTION
## Description
An instance of `granary` is running on a simple VPS; we are pointing to that to attempt a CI build now.