### PR TITLE
fix: default to Docker Hub petros; repository name from image name

### DIFF
--- a/.github/scripts/create-release.js
+++ b/.github/scripts/create-release.js
@@ -20,7 +20,6 @@ module.exports = async ({ github, context, core }) => {
   const repository = process.env.GITHUB_REPOSITORY;
   const doRegistryName = process.env.DO_REGISTRY_NAME;
   const dhUsername = process.env.DH_USERNAME;
-  const dhRepository = process.env.DH_REPOSITORY;
 
   // Get digest outputs
   const doDigest = process.env.DO_DIGEST;
@@ -48,12 +47,12 @@ ${releaseNotes}
 
 Images have been pushed to the following container registries; some may be private.
 ${ghcrDigest ? `- GHCR: \`ghcr.io/${repository}:${sha}\`` : '- GHCR: ❌'}
-${dhDigest ? `- DHCR: \`${dhUsername}/${dhRepository}:${sha}\`` : '- DHCR: ❌'}
+${dhDigest ? `- DHCR: \`${dhUsername}/${imageName}:${sha}\`` : '- DHCR: ❌'}
 ${doDigest ? `- DOCR: \`registry.digitalocean.com/${doRegistryName}/${imageName}:${sha}\`` : '- DOCR: ❌'}
 
 \`\`\`bash
 docker pull ghcr.io/${repository}@${ghcrDigest}
-docker pull ${dhUsername}/${dhRepository}@${dhDigest}
+docker pull ${dhUsername}/${imageName}@${dhDigest}
 docker pull registry.digitalocean.com/${doRegistryName}/${imageName}@${doDigest}
 \`\`\`
 

--- a/.github/scripts/rollback-registries.sh
+++ b/.github/scripts/rollback-registries.sh
@@ -13,7 +13,6 @@
 #   - DH_TOKEN: Docker Hub token
 #   - DH_USERNAME: Docker Hub username
 #   - DO_REGISTRY_NAME: DigitalOcean registry name
-#   - DH_REPOSITORY: Docker Hub repository name
 #   - IMAGE_NAME: Image name
 #   - GITHUB_SHA: Git commit SHA
 #   - GITHUB_REPOSITORY: Repository name (owner/repo)
@@ -137,7 +136,7 @@ if [ -n "$DH_DIGEST" ]; then
   if [ -n "$TOKEN" ]; then
     RESPONSE=$(curl -X DELETE \
       -H "Authorization: Bearer $TOKEN" \
-      "https://hub.docker.com/v2/repositories/$DH_USERNAME/$DH_REPOSITORY/tags/$GITHUB_SHA/" \
+      "https://hub.docker.com/v2/repositories/$DH_USERNAME/$IMAGE_NAME/tags/$GITHUB_SHA/" \
       -w "\n%{http_code}" -s)
 
     HTTP_CODE=$(echo "$RESPONSE" | tail -n 1)

--- a/.github/scripts/sign-release-artifacts.sh
+++ b/.github/scripts/sign-release-artifacts.sh
@@ -17,7 +17,6 @@
 #   - DH_DIGEST: Docker Hub digest
 #   - DO_REGISTRY_NAME: DigitalOcean registry name
 #   - DH_USERNAME: Docker Hub username
-#   - DH_REPOSITORY: Docker Hub repository name
 
 set -e
 
@@ -58,7 +57,7 @@ $DO_DIGEST
 
 Registry URLs:
 - ghcr.io/$GITHUB_REPOSITORY@$GHCR_DIGEST
-- $DH_USERNAME/$DH_REPOSITORY@$DH_DIGEST
+- $DH_USERNAME/$IMAGE_NAME@$DH_DIGEST
 - registry.digitalocean.com/$DO_REGISTRY_NAME/$IMAGE_NAME@$DO_DIGEST
 EOF
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         id: config
         run: |
           . /opt/github-runner/secrets/registry.env
-          BUILD_IMAGE="${BUILD_IMAGE:-petros:latest}"
+          BUILD_IMAGE="${BUILD_IMAGE:-unattended/petros:latest}"
           echo "build-image=$BUILD_IMAGE" >> $GITHUB_OUTPUT
           echo "Using build image: $BUILD_IMAGE"
 
@@ -116,7 +116,6 @@ jobs:
         # Export to environment for subsequent steps
         echo "DO_REGISTRY_NAME=$DO_REGISTRY_NAME" >> $GITHUB_ENV
         echo "DH_USERNAME=$DH_USERNAME" >> $GITHUB_ENV
-        echo "DH_REPOSITORY=$DH_REPOSITORY" >> $GITHUB_ENV
 
     - name: Generate release notes
       id: release-notes
@@ -221,7 +220,7 @@ jobs:
       id: push-dh
       timeout-minutes: 30
       run: |
-        DH_IMAGE="${{ env.DH_USERNAME }}/${{ env.DH_REPOSITORY }}"
+        DH_IMAGE="${{ env.DH_USERNAME }}/${{ env.IMAGE_NAME }}"
         docker tag "${{ env.IMAGE_NAME }}:${{ github.sha }}" \
           "${DH_IMAGE}:${{ github.sha }}"
         PUSH_OUTPUT=$(docker push "${DH_IMAGE}:${{ github.sha }}" 2>&1)
@@ -283,7 +282,7 @@ jobs:
         docker push "${GHCR_IMAGE}:latest"
 
         # Docker Hub
-        DH_IMAGE="${{ env.DH_USERNAME }}/${{ env.DH_REPOSITORY }}"
+        DH_IMAGE="${{ env.DH_USERNAME }}/${{ env.IMAGE_NAME }}"
         docker tag "${DH_IMAGE}:${{ github.sha }}" \
           "${DH_IMAGE}:latest"
         docker push "${DH_IMAGE}:latest"
@@ -321,7 +320,9 @@ jobs:
 
     - name: Perform rollback on failure
       id: rollback
-      if: failure()
+      if: >-
+        failure() &&
+        steps.build.outputs.build_success == 'true'
       env:
         DO_DIGEST: ${{ steps.push-do.outputs.digest }}
         GHCR_DIGEST: ${{ steps.push-ghcr.outputs.digest }}
@@ -329,7 +330,9 @@ jobs:
       run: sh .github/scripts/rollback-registries.sh
 
     - name: Create rollback record
-      if: failure()
+      if: >-
+        failure() &&
+        steps.build.outputs.build_success == 'true'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
       continue-on-error: true
       env:

--- a/README.md
+++ b/README.md
@@ -45,21 +45,18 @@ This file contains non-sensitive registry identifiers and build configuration:
 
 ```bash
 # The Docker image to perform release builds with.
-# If not set, defaults to petros:latest from Docker Hub.
+# If not set, defaults to unattended/petros:latest from Docker Hub.
 # Examples:
 #   BUILD_IMAGE=registry.digitalocean.com/sigil/petros:latest
 #   BUILD_IMAGE=ghcr.io/your-org/petros:latest
-#   BUILD_IMAGE=petros:latest
-BUILD_IMAGE=petros:latest
+#   BUILD_IMAGE=unattended/petros:latest
+BUILD_IMAGE=unattended/petros:latest
 
 # The name of the DigitalOcean registry to publish the built image to.
 DO_REGISTRY_NAME=your-registry-name
 
 # The username of the Docker Hub account to publish the built image to.
 DH_USERNAME=your-dockerhub-username
-
-# The name of the Docker Hub repository to publish the built image to.
-DH_REPOSITORY=petros
 ```
 ### Public Configuration
 

--- a/docs/WORKFLOW_TESTING.md
+++ b/docs/WORKFLOW_TESTING.md
@@ -29,21 +29,18 @@ echo "test-gpg-public-key-base64" > .act-secrets/gpg_public_key
 
 cat > .act-secrets/registry.env <<'EOF'
 # The Docker image to perform release builds with.
-# If not set, defaults to petros:latest from Docker Hub
+# If not set, defaults to unattended/petros:latest from Docker Hub
 # Examples:
 #   BUILD_IMAGE=registry.digitalocean.com/sigil/petros:latest
 #   BUILD_IMAGE=ghcr.io/your-org/petros:latest
-#   BUILD_IMAGE=petros:latest
-BUILD_IMAGE=petros:latest
+#   BUILD_IMAGE=unattended/petros:latest
+BUILD_IMAGE=unattended/petros:latest
 
 # The name of the DigitalOcean registry to publish the built image to.
 DO_REGISTRY_NAME=sigil
 
 # The username of the Docker Hub account to publish the built image to.
 DH_USERNAME=unattended
-
-# The name of the Docker Hub repository to publish the built image to.
-DH_REPOSITORY=petros
 EOF
 
 chmod 700 .act-secrets


### PR DESCRIPTION
## Description
A `DH_REPOSITORY` variable is no longer required; this is now forced to equal the `IMAGE_NAME` from `.env.maintainer`.

## Bug Fixes 
The previous change did not include the Docker Hub username in the default build image.
