### PR TITLE
fix: cosign is now noninteractive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description
Cosign was not working because I was not requesting OIDC permissions in the GitHub Actions workflow.

## Bug Fixes  
The workflow has OIDC permissions for cosign to work automatically now; this lets it be attributable to this specific action run.