### PR TITLE
fix: the release workflow performs cleanup on the self-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - '**/*.txt'
       - 'docs/**'
       - '.github/workflows/codeql.yml'
+      - '.github/workflows/release.yml'
 
 permissions:
   actions: read
@@ -65,6 +66,20 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+
+    - name: Clean up Docker resources
+      run: |
+        echo "Current disk usage:"
+        df -h
+        docker system df || true
+
+        echo "Cleaning up Docker resources..."
+        docker builder prune -af || true
+        docker container prune -f || true
+        docker image prune -af || true
+
+        echo "After cleanup:"
+        df -h
 
     - name: Generate build metadata
       id: metadata


### PR DESCRIPTION
## Description

## Bug Fixes  
Sometimes the self-hosted runner would run out of disk space for consecutive large builds without cleanup. Now Petros performs proper cleanup.